### PR TITLE
copy additional resources, parse file globs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,7 @@ module.exports = function (grunt) {
 
     jasmine_firefoxaddon: {
       tests: ['test/selftest.js'],
+      resources: ['test/resource*.js'],
       helpers: ['test/testHelper.jsm']
     },
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ iterations of this tool may be able to make the process smoother.
 Customize your SpecRunner
 -------------------------
 
-Use your own files in the app to customize your tests. 
-
+Use your own files in the app to customize your tests. For all of the below, you
+can use [node globbing patterns](https://github.com/isaacs/node-glob).
 
 ### Options
 
@@ -58,11 +58,24 @@ Type: `String|Array`
 
 The spec files you want to run.
 
+#### resources
+Type: `String|Array`
+
+Resources (.js, .json, etc.) needed for the tests (will be made available to the
+addon under `data/scripts`, but *not* automatically loaded into the addon - your
+tests can pull them in as needed from
+`jid1-mkagayemb0e5nq-at-jetpack/data/scripts`). These files *can* be `.jsm`,
+which would allow them to be loaded via `Components.utils.import`, or they can
+be of other types (which will require different mechanisms to load, currently
+left as an exercise to the user - future updates to this tool may try to smooth
+common use cases).
+
 #### helpers
 Type: `String|Array`
 
 Custom JavaScript module (`.jsm`) files you wish you load into your addon during
-test.
+test. These files *are* automatically loaded during addon setup, but *must* be
+`.jsm` types (JavaScript with an `EXPORTED_SYMBOLS` array to define visibility).
 
 #### options.timeout
 Type: `Number`

--- a/test/resource1.js
+++ b/test/resource1.js
@@ -1,0 +1,3 @@
+EXPORTED_SYMBOLS = ["resource1"];
+
+var resource1 = "Loaded first resource file";

--- a/test/resource2.js
+++ b/test/resource2.js
@@ -1,0 +1,3 @@
+EXPORTED_SYMBOLS = ["resource2"];
+
+var resource2 = "Loaded second resource file";

--- a/test/selftest.js
+++ b/test/selftest.js
@@ -6,9 +6,16 @@ describe('jasmine-chromeapp', function () {
     expect(true).toBe(true);
   });
 
-  it('Has helper files copied appropriately', function (done) {
+  it('Copies resource files', function () {
+    var datapath = 'resource://jid1-mkagayemb0e5nq-at-jetpack/data/scripts/';
+    Components.utils.import(datapath + 'test/resource1.js');
+    Components.utils.import(datapath + 'test/resource2.js');
+    expect(resource1).toBe('Loaded first resource file');
+    expect(resource2).toBe('Loaded second resource file');
+  });
+
+  it('Has helper files copied appropriately', function () {
     // Checks to see that testHelper.jsm was loaded
     expect(test()).toBe('helper loaded');
-    done();
   });
 });


### PR DESCRIPTION
Fix #3 - also enables file glob patterns for all options. This tool is now fairly functional, though loading resources within a Firefox addon is somewhat inevitably clunky. Specific caveats:
- ugly hash-y path (the `self` sdk cannot be accessed in all scopes, so the path sometimes needs to be hardcoded)
- `.jsm` modules can be loaded with `Components.utils.import` but other things (e.g. `.json`, `.js`) don't have a consistent way to be pulled in

On the plus side, `freedom.js` does work just fine when pointed at a `.json` file (loads it and runs whatever module it has with it), so I think it will suffice for our tests.
